### PR TITLE
feat: Fixes #11, added secret reloader

### DIFF
--- a/.source/secrets/reloader/config/overlays/deployment.yaml
+++ b/.source/secrets/reloader/config/overlays/deployment.yaml
@@ -1,0 +1,116 @@
+---
+commonOverlays:
+  - name: "apply nukleros labels"
+    query: "metadata.labels"
+    value:
+      app.kubernetes.io/name: "{{ .name }}"
+      platform.nukleros.io/group: "{{ .group }}"
+      platform.nukleros.io/project: "{{ .project }}"
+    # replace labels here to remove all of the helm info
+    action: replace
+    onMissing:
+      action: inject
+
+  - name: "apply nukleros labels to pod template"
+    query: "spec.template.metadata.labels"
+    value:
+      app.kubernetes.io/name: "{{ .name }}"
+      platform.nukleros.io/group: "{{ .group }}"
+      platform.nukleros.io/project: "{{ .project }}"
+    # replace labels here to remove all of the helm info
+    action: replace
+    onMissing:
+      action: inject
+
+  - name: "apply selector matching"
+    query: "spec.selector.matchLabels"
+    value:
+      app.kubernetes.io/name: "{{ .name }}"
+      platform.nukleros.io/group: "{{ .group }}"
+      platform.nukleros.io/project: "{{ .project }}"
+    # replace labels here to remove all of the helm info
+    action: replace
+    onMissing:
+      action: inject
+
+  - name: "remove helm annotations"
+    query: "metadata.annotations"
+    action: delete
+
+  - name: "rename resources to remove duplication (e.g. reloader-reloader)"
+    query: "metadata.name"
+    value: "{{ .name }}"
+
+yamlFiles:
+  - name: "reloader deployments"
+    path: "../../vendor/reloader.yaml"
+    outputPath: "secrets/reloader/deployment.yaml"
+    overlays:
+      - name: "ensure we are only acting upon deployment resources"
+        query: "$"
+        action: delete
+        documentQuery:
+          - conditions:
+              - query: $[?($.kind != "Deployment")]
+
+      - name: "ensure namespace is updated"
+        query: metadata.namespace
+        value: "{{ .namespace }}"
+
+      - name: "ensure container name is updated"
+        query: spec.template.spec.containers[?(@.name == "reloader-reloader")]
+        value:
+          name: "{{ .name }}"
+
+      - name: "ensure container security context is updated"
+        query: spec.template.spec.containers[*]
+        onMissing:
+          action: inject
+        value:
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+            runAsUser: 65534
+
+      - name: "ensure controller resources are updated"
+        query: spec.template.spec.containers[*]
+        value:
+          resources:
+            requests:
+              cpu: "{{ .resources.requests.cpu }}"
+              memory: "{{ .resources.requests.memory }}"
+            limits:
+              cpu: "{{ .resources.limits.cpu }}"
+              memory: "{{ .resources.limits.memory }}"
+        documentQuery:
+          - conditions:
+              - query: $[?($.metadata.name == "secret-reloader")]
+
+      - name: "ensure other controller changes are made"
+        query: spec
+        action: merge
+        value:
+          replicas: !!int {{ .replicas }}
+          template:
+            spec:
+              serviceAccountName: "{{ .name }}"
+              affinity:
+                podAntiAffinity:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                    - weight: 100
+                      podAffinityTerm:
+                        topologyKey: kubernetes.io/hostname
+                        labelSelector:
+                          matchExpressions:
+                            - key: app.kubernetes.io/name
+                              operator: In
+                              values:
+                                - reloader
+              nodeSelector:
+                kubernetes.io/os: linux
+        documentQuery:
+          - conditions:
+              - query: $[?($.metadata.name == "secret-reloader")]

--- a/.source/secrets/reloader/config/overlays/rbac.yaml
+++ b/.source/secrets/reloader/config/overlays/rbac.yaml
@@ -1,0 +1,56 @@
+---
+commonOverlays:
+  - name: "apply nukleros labels"
+    query: "metadata.labels"
+    value:
+      platform.nukleros.io/group: "{{ .group }}"
+      platform.nukleros.io/project: "{{ .project }}"
+    # replace labels here to remove all of the helm info
+    action: replace
+    onMissing:
+      action: inject
+
+  - name: "remove helm annotations"
+    query: "metadata.annotations"
+    action: delete
+
+  - name: "rename resources to remove duplication (e.g. reloader-reloader)"
+    query:
+      - "metadata.name"
+      - "subjects[*].name"
+      - "roleRef.name"
+    value: "{{ .name }}"
+
+yamlFiles:
+  - name: "reloader rbac"
+    path: "../../vendor/reloader.yaml"
+    outputPath: "secrets/reloader/rbac.yaml"
+    overlays:
+      # TODO: this doesn't remove the namespace like it should.  although it will not affect
+      #       functionality, it would be nice if this were consistent
+      - name: "remove namespace from cluster-scoped resources"
+        query: "metadata.namespace"
+        action: delete
+        documentQuery:
+          - conditions:
+              - query: $[?($.kind == "ClusterRole")]
+              - query: $[?($.kind == "ClusterRoleBinding")]
+
+      - name: "ensure we are only acting upon rbac resources"
+        query: "$"
+        action: delete
+        documentQuery:
+          - conditions:
+              - query: $[?($.kind != "ServiceAccount")]
+              - query: $[?($.kind != "Role")]
+              - query: $[?($.kind != "RoleBinding")]
+              - query: $[?($.kind != "ClusterRole")]
+              - query: $[?($.kind != "ClusterRoleBinding")]
+
+      - name: "ensure namespace is updated"
+        query:
+          - metadata.namespace
+          - subjects[*].namespace
+        value: "{{ .namespace }}"
+        onMissing:
+          action: ignore

--- a/.source/secrets/reloader/config/values.yaml
+++ b/.source/secrets/reloader/config/values.yaml
@@ -1,0 +1,11 @@
+---
+name: secret-reloader
+project: reloader
+replicas: 1
+resources:
+  requests:
+    cpu: "25m"
+    memory: "32Mi"
+  limits:
+    cpu: "50m"
+    memory: "64Mi"

--- a/.source/secrets/reloader/config/vendor.yaml
+++ b/.source/secrets/reloader/config/vendor.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: vendir.k14s.io/v1alpha1
+kind: Config
+minimumRequiredVersion: 0.30.0
+directories:
+  - path: .source/secrets/reloader/vendor
+    contents:
+      - path: ./
+        http:
+          url: https://raw.githubusercontent.com/stakater/Reloader/v0.0.119/deployments/kubernetes/reloader.yaml

--- a/.source/secrets/reloader/config/vendor.yaml.lock
+++ b/.source/secrets/reloader/config/vendor.yaml.lock
@@ -1,0 +1,7 @@
+apiVersion: vendir.k14s.io/v1alpha1
+directories:
+- contents:
+  - http: {}
+    path: ./
+  path: .source/secrets/reloader/vendor
+kind: LockConfig

--- a/.source/secrets/reloader/vendor/reloader.yaml
+++ b/.source/secrets/reloader/vendor/reloader.yaml
@@ -1,0 +1,155 @@
+---
+# Source: reloader/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    meta.helm.sh/release-namespace: "default"
+    meta.helm.sh/release-name: "reloader"
+  labels:
+    app: reloader-reloader
+    chart: "reloader-v0.0.119"
+    release: "reloader"
+    heritage: "Helm"
+    app.kubernetes.io/managed-by: "Helm"
+  name: reloader-reloader
+  namespace: default
+---
+# Source: reloader/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+
+kind: ClusterRole
+metadata:
+  annotations:
+    meta.helm.sh/release-namespace: "default"
+    meta.helm.sh/release-name: "reloader"
+  labels:
+    app: reloader-reloader
+    chart: "reloader-v0.0.119"
+    release: "reloader"
+    heritage: "Helm"
+    app.kubernetes.io/managed-by: "Helm"
+  name: reloader-reloader-role
+  namespace: default
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+      - configmaps
+    verbs:
+      - list
+      - get
+      - watch
+  - apiGroups:
+      - "apps"
+    resources:
+      - deployments
+      - daemonsets
+      - statefulsets
+    verbs:
+      - list
+      - get
+      - update
+      - patch
+  - apiGroups:
+      - "extensions"
+    resources:
+      - deployments
+      - daemonsets
+    verbs:
+      - list
+      - get
+      - update
+      - patch
+---
+# Source: reloader/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    meta.helm.sh/release-namespace: "default"
+    meta.helm.sh/release-name: "reloader"
+  labels:
+    app: reloader-reloader
+    chart: "reloader-v0.0.119"
+    release: "reloader"
+    heritage: "Helm"
+    app.kubernetes.io/managed-by: "Helm"
+  name: reloader-reloader-role-binding
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: reloader-reloader-role
+subjects:
+  - kind: ServiceAccount
+    name: reloader-reloader
+    namespace: default
+---
+# Source: reloader/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    meta.helm.sh/release-namespace: "default"
+    meta.helm.sh/release-name: "reloader"
+  labels:
+    app: reloader-reloader
+    chart: "reloader-v0.0.119"
+    release: "reloader"
+    heritage: "Helm"
+    app.kubernetes.io/managed-by: "Helm"
+    group: com.stakater.platform
+    provider: stakater
+    version: v0.0.119
+  name: reloader-reloader
+  namespace: default
+spec:
+  replicas: 1
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: reloader-reloader
+      release: "reloader"
+  template:
+    metadata:
+      labels:
+        app: reloader-reloader
+        chart: "reloader-v0.0.119"
+        release: "reloader"
+        heritage: "Helm"
+        app.kubernetes.io/managed-by: "Helm"
+        group: com.stakater.platform
+        provider: stakater
+        version: v0.0.119
+    spec:
+      containers:
+      - image: "stakater/reloader:v0.0.119"
+        imagePullPolicy: IfNotPresent
+        name: reloader-reloader
+
+        ports:
+        - name: http
+          containerPort: 9090
+        livenessProbe:
+          httpGet:
+            path: /metrics
+            port: http
+          timeoutSeconds: 5
+          failureThreshold: 5
+          periodSeconds: 10
+          successThreshold: 1
+        readinessProbe:
+          httpGet:
+            path: /metrics
+            port: http
+          timeoutSeconds: 5
+          failureThreshold: 5
+          periodSeconds: 10
+          successThreshold: 1
+      securityContext: 
+        runAsNonRoot: true
+        runAsUser: 65534
+      serviceAccountName: reloader-reloader

--- a/secrets/reloader/deployment.yaml
+++ b/secrets/reloader/deployment.yaml
@@ -1,0 +1,80 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/name: secret-reloader
+    platform.nukleros.io/group: secrets
+    platform.nukleros.io/project: reloader
+  name: secret-reloader
+  namespace: nukleros-secrets-system
+spec:
+  replicas: 1
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: secret-reloader
+      platform.nukleros.io/group: secrets
+      platform.nukleros.io/project: reloader
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: secret-reloader
+        platform.nukleros.io/group: secrets
+        platform.nukleros.io/project: reloader
+    spec:
+      containers:
+        - image: stakater/reloader:v0.0.119
+          imagePullPolicy: IfNotPresent
+          name: secret-reloader
+          ports:
+            - name: http
+              containerPort: 9090
+          livenessProbe:
+            httpGet:
+              path: /metrics
+              port: http
+            timeoutSeconds: 5
+            failureThreshold: 5
+            periodSeconds: 10
+            successThreshold: 1
+          readinessProbe:
+            httpGet:
+              path: /metrics
+              port: http
+            timeoutSeconds: 5
+            failureThreshold: 5
+            periodSeconds: 10
+            successThreshold: 1
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+            runAsUser: 65534
+          resources:
+            requests:
+              cpu: 25m
+              memory: 32Mi
+            limits:
+              cpu: 50m
+              memory: 64Mi
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+      serviceAccountName: secret-reloader
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchExpressions:
+                    - key: app.kubernetes.io/name
+                      operator: In
+                      values:
+                        - reloader
+      nodeSelector:
+        kubernetes.io/os: linux

--- a/secrets/reloader/rbac.yaml
+++ b/secrets/reloader/rbac.yaml
@@ -1,0 +1,66 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    platform.nukleros.io/group: secrets
+    platform.nukleros.io/project: reloader
+  name: secret-reloader
+  namespace: nukleros-secrets-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    platform.nukleros.io/group: secrets
+    platform.nukleros.io/project: reloader
+  name: secret-reloader
+  namespace: nukleros-secrets-system
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+      - configmaps
+    verbs:
+      - list
+      - get
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+      - daemonsets
+      - statefulsets
+    verbs:
+      - list
+      - get
+      - update
+      - patch
+  - apiGroups:
+      - extensions
+    resources:
+      - deployments
+      - daemonsets
+    verbs:
+      - list
+      - get
+      - update
+      - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    platform.nukleros.io/group: secrets
+    platform.nukleros.io/project: reloader
+  name: secret-reloader
+  namespace: nukleros-secrets-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: secret-reloader
+subjects:
+  - kind: ServiceAccount
+    name: secret-reloader
+    namespace: nukleros-secrets-system


### PR DESCRIPTION
This adds support for the secret reloader which is a controller that watches for changes to deployment-like resources, detects which secrets and configmaps they are using, and automatically reloads them when changes are detected.

Signed-off-by: Dustin Scott <dustin.scott18@gmail.com>