### PR TITLE
feat: rename group tag to category

### DIFF
--- a/.scripts/download.sh
+++ b/.scripts/download.sh
@@ -4,14 +4,14 @@ set -e
 
 # DESCRIPTION: performs the download of a set of manifests, using vendir, from an upstream
 # INPUTS:
-#   GROUP:   the group classification, from the parent directory in .source (e.g. certificates, ingress)
-#   PROJECT: the project, within the GROUP, to download
+#   CATEGORY: the category of components, from the parent directory in .source (e.g. certificates, ingress)
+#   PROJECT: the project, within the CATEGORY, to download
 #
 # USAGE:
-#   GROUP=secrets PROJECT=external-secrets scripts/download.sh
+#   CATEGORY=secrets PROJECT=external-secrets scripts/download.sh
 
 # validate the environment
-: ${GROUP?missing environment variable GROUP}
+: ${CATEGORY?missing environment variable CATEGORY}
 : ${PROJECT?missing environment variable PROJECT}
 
 if [ -z `which vendir` ]; then
@@ -19,7 +19,7 @@ if [ -z `which vendir` ]; then
     exit 1
 fi
 
-PROJECT_DIR=".source/${GROUP}/${PROJECT}"
+PROJECT_DIR=".source/${CATEGORY}/${PROJECT}"
 
 # sync the project
 # NOTE: this is meant to be run from a make target and will not work

--- a/.scripts/overlay.sh
+++ b/.scripts/overlay.sh
@@ -5,14 +5,14 @@ set -e
 # DESCRIPTION: performs the overlaying a set of manifests.  this is a simply script for now, but may
 #              grow over time so we will keep logic out of the Makefile
 # INPUTS:
-#   GROUP:   the group classification, from the parent directory in .source (e.g. certificates, ingress)
-#   PROJECT: the project, within the GROUP, to overlay
+#   CATEGORY: the category of components, from the parent directory in .source (e.g. certificates, ingress)
+#   PROJECT: the project, within the CATEGORY, to overlay
 #
 # USAGE:
-#   GROUP=secrets PROJECT=external-secrets scripts/overlay.sh
+#   CATEGORY=secrets PROJECT=external-secrets scripts/overlay.sh
 
 # validate the environment
-: ${GROUP?missing environment variable GROUP}
+: ${CATEGORY?missing environment variable CATEGORY}
 : ${PROJECT?missing environment variable PROJECT}
 
 if [ -z `which yot` ]; then
@@ -20,12 +20,12 @@ if [ -z `which yot` ]; then
     exit 1
 fi
 
-GROUP_DIR=".source/${GROUP}"
-PROJECT_DIR="${GROUP_DIR}/${PROJECT}"
+CATEGORY_DIR=".source/${CATEGORY}"
+PROJECT_DIR="${CATEGORY_DIR}/${PROJECT}"
 
-# ensure group values exist
-if [ ! -f ${GROUP_DIR}/values.yaml ]; then
-    echo "missing group-specific values file at ${GROUP_DIR}/values.yaml..."
+# ensure category values exist
+if [ ! -f ${CATEGORY_DIR}/values.yaml ]; then
+    echo "missing category-specific values file at ${CATEGORY_DIR}/values.yaml..."
     exit 1
 fi
 
@@ -41,9 +41,9 @@ for OVERLAY in `ls ${PROJECT_DIR}/config/overlays`; do \
         --instructions=${PROJECT_DIR}/config/overlays/${OVERLAY} \
         --output-directory=. \
         --values-file=${PROJECT_DIR}/config/values.yaml \
-        --values-file=${GROUP_DIR}/values.yaml \
+        --values-file=${CATEGORY_DIR}/values.yaml \
         --remove-comments \
-        --stdout > ${GROUP}/${PROJECT}/${OVERLAY}
+        --stdout > ${CATEGORY}/${PROJECT}/${OVERLAY}
     
     # TODO: remove duplication in overlays for nukleros labels
     # run the stdout through our common overlays
@@ -51,7 +51,7 @@ for OVERLAY in `ls ${PROJECT_DIR}/config/overlays`; do \
     #    --path=- \
     #    --instructions=.source/overlay.yaml \
     #    --values-file=${PROJECT_DIR}/config/values.yaml \
-    #    --values-file=${GROUP_DIR}/values.yaml \
+    #    --values-file=${CATEGORY_DIR}/values.yaml \
     #    --remove-comments \
-    #    --stdout > ${GROUP}/${PROJECT}/${OVERLAY}
+    #    --stdout > ${CATEGORY}/${PROJECT}/${OVERLAY}
 done

--- a/.source/certificates/cert-manager/config/overlays/crds.yaml
+++ b/.source/certificates/cert-manager/config/overlays/crds.yaml
@@ -3,7 +3,7 @@ commonOverlays:
   - name: "apply nukleros labels"
     query: "metadata.labels"
     value:
-      platform.nukleros.io/group: "{{ .group }}"
+      platform.nukleros.io/category: "{{ .category }}"
       platform.nukleros.io/project: "{{ .project }}"
     onMissing:
       action: inject

--- a/.source/certificates/cert-manager/config/overlays/deployment.yaml
+++ b/.source/certificates/cert-manager/config/overlays/deployment.yaml
@@ -3,7 +3,7 @@ commonOverlays:
   - name: "apply nukleros labels"
     query: "metadata.labels"
     value:
-      platform.nukleros.io/group: "{{ .group }}"
+      platform.nukleros.io/category: "{{ .category }}"
       platform.nukleros.io/project: "{{ .project }}"
     onMissing:
       action: inject
@@ -11,7 +11,7 @@ commonOverlays:
   - name: "apply nukleros labels to pod template"
     query: "spec.template.metadata.labels"
     value:
-      platform.nukleros.io/group: "{{ .group }}"
+      platform.nukleros.io/category: "{{ .category }}"
       platform.nukleros.io/project: "{{ .project }}"
     onMissing:
       action: inject

--- a/.source/certificates/cert-manager/config/overlays/rbac.yaml
+++ b/.source/certificates/cert-manager/config/overlays/rbac.yaml
@@ -3,7 +3,7 @@ commonOverlays:
   - name: "apply nukleros labels"
     query: "metadata.labels"
     value:
-      platform.nukleros.io/group: "{{ .group }}"
+      platform.nukleros.io/category: "{{ .category }}"
       platform.nukleros.io/project: "{{ .project }}"
     onMissing:
       action: inject

--- a/.source/certificates/cert-manager/config/overlays/service.yaml
+++ b/.source/certificates/cert-manager/config/overlays/service.yaml
@@ -3,7 +3,7 @@ commonOverlays:
   - name: "apply nukleros labels"
     query: "metadata.labels"
     value:
-      platform.nukleros.io/group: "{{ .group }}"
+      platform.nukleros.io/category: "{{ .category }}"
       platform.nukleros.io/project: "{{ .project }}"
     onMissing:
       action: inject

--- a/.source/certificates/cert-manager/config/overlays/webhook.yaml
+++ b/.source/certificates/cert-manager/config/overlays/webhook.yaml
@@ -3,7 +3,7 @@ commonOverlays:
   - name: "apply nukleros labels"
     query: "metadata.labels"
     value:
-      platform.nukleros.io/group: "{{ .group }}"
+      platform.nukleros.io/category: "{{ .category }}"
       platform.nukleros.io/project: "{{ .project }}"
     onMissing:
       action: inject

--- a/.source/certificates/values.yaml
+++ b/.source/certificates/values.yaml
@@ -1,3 +1,3 @@
 ---
 namespace: nukleros-certs-system
-group: certificates
+category: certificates

--- a/.source/ingress/external-dns/config/overlays/config-active-directory.yaml
+++ b/.source/ingress/external-dns/config/overlays/config-active-directory.yaml
@@ -3,7 +3,7 @@ commonOverlays:
   - name: "apply nukleros labels"
     query: "metadata.labels"
     value:
-      platform.nukleros.io/group: "{{ .group }}"
+      platform.nukleros.io/category: "{{ .category }}"
       platform.nukleros.io/project: "{{ .project }}"
     onMissing:
       action: inject

--- a/.source/ingress/external-dns/config/overlays/config-google.yaml
+++ b/.source/ingress/external-dns/config/overlays/config-google.yaml
@@ -3,7 +3,7 @@ commonOverlays:
   - name: "apply nukleros labels"
     query: "metadata.labels"
     value:
-      platform.nukleros.io/group: "{{ .group }}"
+      platform.nukleros.io/category: "{{ .category }}"
       platform.nukleros.io/project: "{{ .project }}"
     onMissing:
       action: inject

--- a/.source/ingress/external-dns/config/overlays/config-route53.yaml
+++ b/.source/ingress/external-dns/config/overlays/config-route53.yaml
@@ -3,7 +3,7 @@ commonOverlays:
   - name: "apply nukleros labels"
     query: "metadata.labels"
     value:
-      platform.nukleros.io/group: "{{ .group }}"
+      platform.nukleros.io/category: "{{ .category }}"
       platform.nukleros.io/project: "{{ .project }}"
     onMissing:
       action: inject

--- a/.source/ingress/external-dns/config/overlays/deployment-active-directory.yaml
+++ b/.source/ingress/external-dns/config/overlays/deployment-active-directory.yaml
@@ -26,7 +26,7 @@ commonOverlays:
   - name: "apply nukleros labels"
     query: "metadata.labels"
     value:
-      platform.nukleros.io/group: "{{ .group }}"
+      platform.nukleros.io/category: "{{ .category }}"
       platform.nukleros.io/project: "{{ .project }}"
     onMissing:
       action: inject
@@ -34,7 +34,7 @@ commonOverlays:
   - name: "apply nukleros labels to pod template"
     query: "spec.template.metadata.labels"
     value:
-      platform.nukleros.io/group: "{{ .group }}"
+      platform.nukleros.io/category: "{{ .category }}"
       platform.nukleros.io/project: "{{ .project }}"
     onMissing:
       action: inject

--- a/.source/ingress/external-dns/config/overlays/deployment-google.yaml
+++ b/.source/ingress/external-dns/config/overlays/deployment-google.yaml
@@ -26,7 +26,7 @@ commonOverlays:
   - name: "apply nukleros labels"
     query: "metadata.labels"
     value:
-      platform.nukleros.io/group: "{{ .group }}"
+      platform.nukleros.io/category: "{{ .category }}"
       platform.nukleros.io/project: "{{ .project }}"
     onMissing:
       action: inject
@@ -34,7 +34,7 @@ commonOverlays:
   - name: "apply nukleros labels to pod template"
     query: "spec.template.metadata.labels"
     value:
-      platform.nukleros.io/group: "{{ .group }}"
+      platform.nukleros.io/category: "{{ .category }}"
       platform.nukleros.io/project: "{{ .project }}"
     onMissing:
       action: inject

--- a/.source/ingress/external-dns/config/overlays/deployment-route53.yaml
+++ b/.source/ingress/external-dns/config/overlays/deployment-route53.yaml
@@ -26,7 +26,7 @@ commonOverlays:
   - name: "apply nukleros labels"
     query: "metadata.labels"
     value:
-      platform.nukleros.io/group: "{{ .group }}"
+      platform.nukleros.io/category: "{{ .category }}"
       platform.nukleros.io/project: "{{ .project }}"
     onMissing:
       action: inject
@@ -34,7 +34,7 @@ commonOverlays:
   - name: "apply nukleros labels to pod template"
     query: "spec.template.metadata.labels"
     value:
-      platform.nukleros.io/group: "{{ .group }}"
+      platform.nukleros.io/category: "{{ .category }}"
       platform.nukleros.io/project: "{{ .project }}"
     onMissing:
       action: inject

--- a/.source/ingress/external-dns/config/overlays/rbac.yaml
+++ b/.source/ingress/external-dns/config/overlays/rbac.yaml
@@ -3,7 +3,7 @@ commonOverlays:
   - name: "apply nukleros labels"
     query: "metadata.labels"
     value:
-      platform.nukleros.io/group: "{{ .group }}"
+      platform.nukleros.io/category: "{{ .category }}"
       platform.nukleros.io/project: "{{ .project }}"
     onMissing:
       action: inject

--- a/.source/ingress/kong/config/overlays/crds.yaml
+++ b/.source/ingress/kong/config/overlays/crds.yaml
@@ -3,7 +3,7 @@ commonOverlays:
   - name: "apply nukleros labels"
     query: "metadata.labels"
     value:
-      platform.nukleros.io/group: "{{ .group }}"
+      platform.nukleros.io/category: "{{ .category }}"
       platform.nukleros.io/project: "{{ .project }}"
     onMissing:
       action: inject

--- a/.source/ingress/kong/config/overlays/deployment.yaml
+++ b/.source/ingress/kong/config/overlays/deployment.yaml
@@ -3,7 +3,7 @@ commonOverlays:
   - name: "apply nukleros labels"
     query: "metadata.labels"
     value:
-      platform.nukleros.io/group: "{{ .group }}"
+      platform.nukleros.io/category: "{{ .category }}"
       platform.nukleros.io/project: "{{ .project }}"
     onMissing:
       action: inject
@@ -11,7 +11,7 @@ commonOverlays:
   - name: "apply nukleros labels to pod template"
     query: "spec.template.metadata.labels"
     value:
-      platform.nukleros.io/group: "{{ .group }}"
+      platform.nukleros.io/category: "{{ .category }}"
       platform.nukleros.io/project: "{{ .project }}"
     onMissing:
       action: inject

--- a/.source/ingress/kong/config/overlays/ingress-class.yaml
+++ b/.source/ingress/kong/config/overlays/ingress-class.yaml
@@ -3,7 +3,7 @@ commonOverlays:
   - name: "apply nukleros labels"
     query: "metadata.labels"
     value:
-      platform.nukleros.io/group: "{{ .group }}"
+      platform.nukleros.io/category: "{{ .category }}"
       platform.nukleros.io/project: "{{ .project }}"
     onMissing:
       action: inject

--- a/.source/ingress/kong/config/overlays/rbac.yaml
+++ b/.source/ingress/kong/config/overlays/rbac.yaml
@@ -3,7 +3,7 @@ commonOverlays:
   - name: "apply nukleros labels"
     query: "metadata.labels"
     value:
-      platform.nukleros.io/group: "{{ .group }}"
+      platform.nukleros.io/category: "{{ .category }}"
       platform.nukleros.io/project: "{{ .project }}"
     onMissing:
       action: inject

--- a/.source/ingress/kong/config/overlays/service.yaml
+++ b/.source/ingress/kong/config/overlays/service.yaml
@@ -3,7 +3,7 @@ commonOverlays:
   - name: "apply nukleros labels"
     query: "metadata.labels"
     value:
-      platform.nukleros.io/group: "{{ .group }}"
+      platform.nukleros.io/category: "{{ .category }}"
       platform.nukleros.io/project: "{{ .project }}"
     onMissing:
       action: inject

--- a/.source/ingress/nginx/config/overlays/config.yaml
+++ b/.source/ingress/nginx/config/overlays/config.yaml
@@ -3,7 +3,7 @@ commonOverlays:
   - name: "apply nukleros labels"
     query: "metadata.labels"
     value:
-      platform.nukleros.io/group: "{{ .group }}"
+      platform.nukleros.io/category: "{{ .category }}"
       platform.nukleros.io/project: "{{ .project }}"
     onMissing:
       action: inject

--- a/.source/ingress/nginx/config/overlays/crds.yaml
+++ b/.source/ingress/nginx/config/overlays/crds.yaml
@@ -3,7 +3,7 @@ commonOverlays:
   - name: "apply nukleros labels"
     query: "metadata.labels"
     value:
-      platform.nukleros.io/group: "{{ .group }}"
+      platform.nukleros.io/category: "{{ .category }}"
       platform.nukleros.io/project: "{{ .project }}"
     onMissing:
       action: inject

--- a/.source/ingress/nginx/config/overlays/deployment.yaml
+++ b/.source/ingress/nginx/config/overlays/deployment.yaml
@@ -3,7 +3,7 @@ commonOverlays:
   - name: "apply nukleros labels"
     query: "metadata.labels"
     value:
-      platform.nukleros.io/group: "{{ .group }}"
+      platform.nukleros.io/category: "{{ .category }}"
       platform.nukleros.io/project: "{{ .project }}"
     onMissing:
       action: inject
@@ -11,7 +11,7 @@ commonOverlays:
   - name: "apply nukleros labels to pod template"
     query: "spec.template.metadata.labels"
     value:
-      platform.nukleros.io/group: "{{ .group }}"
+      platform.nukleros.io/category: "{{ .category }}"
       platform.nukleros.io/project: "{{ .project }}"
     onMissing:
       action: inject

--- a/.source/ingress/nginx/config/overlays/ingress-class.yaml
+++ b/.source/ingress/nginx/config/overlays/ingress-class.yaml
@@ -3,7 +3,7 @@ commonOverlays:
   - name: "apply nukleros labels"
     query: "metadata.labels"
     value:
-      platform.nukleros.io/group: "{{ .group }}"
+      platform.nukleros.io/category: "{{ .category }}"
       platform.nukleros.io/project: "{{ .project }}"
     onMissing:
       action: inject

--- a/.source/ingress/nginx/config/overlays/rbac.yaml
+++ b/.source/ingress/nginx/config/overlays/rbac.yaml
@@ -3,7 +3,7 @@ commonOverlays:
   - name: "apply nukleros labels"
     query: "metadata.labels"
     value:
-      platform.nukleros.io/group: "{{ .group }}"
+      platform.nukleros.io/category: "{{ .category }}"
       platform.nukleros.io/project: "{{ .project }}"
     onMissing:
       action: inject

--- a/.source/ingress/nginx/config/overlays/secret.yaml
+++ b/.source/ingress/nginx/config/overlays/secret.yaml
@@ -3,7 +3,7 @@ commonOverlays:
   - name: "apply nukleros labels"
     query: "metadata.labels"
     value:
-      platform.nukleros.io/group: "{{ .group }}"
+      platform.nukleros.io/category: "{{ .category }}"
       platform.nukleros.io/project: "{{ .project }}"
     onMissing:
       action: inject

--- a/.source/ingress/nginx/config/overlays/service-aws.yaml
+++ b/.source/ingress/nginx/config/overlays/service-aws.yaml
@@ -3,7 +3,7 @@ commonOverlays:
   - name: "apply nukleros labels"
     query: "metadata.labels"
     value:
-      platform.nukleros.io/group: "{{ .group }}"
+      platform.nukleros.io/category: "{{ .category }}"
       platform.nukleros.io/project: "{{ .project }}"
     onMissing:
       action: inject

--- a/.source/ingress/nginx/config/overlays/service-gcp-azure.yaml
+++ b/.source/ingress/nginx/config/overlays/service-gcp-azure.yaml
@@ -3,7 +3,7 @@ commonOverlays:
   - name: "apply nukleros labels"
     query: "metadata.labels"
     value:
-      platform.nukleros.io/group: "{{ .group }}"
+      platform.nukleros.io/category: "{{ .category }}"
       platform.nukleros.io/project: "{{ .project }}"
     onMissing:
       action: inject

--- a/.source/ingress/values.yaml
+++ b/.source/ingress/values.yaml
@@ -1,3 +1,3 @@
 ---
 namespace: nukleros-ingress-system
-group: ingress
+category: ingress

--- a/.source/overlay.yaml
+++ b/.source/overlay.yaml
@@ -3,8 +3,8 @@ commonOverlays:
   - name: "apply nukleros labels"
     query: "metadata.labels"
     value:
-      # this implies that the 'group' variable is set
-      platform.nukleros.io/group: "{{ .group }}"
+      # this implies that the 'category' variable is set
+      platform.nukleros.io/category: "{{ .category }}"
 
       # this implies that the 'project' variable is set
       platform.nukleros.io/project: "{{ .project }}"

--- a/.source/secrets/external-secrets/config/overlays/config.yaml
+++ b/.source/secrets/external-secrets/config/overlays/config.yaml
@@ -3,13 +3,13 @@ commonOverlays:
   - name: "apply nukleros labels"
     query: "metadata.labels"
     value:
-      platform.nukleros.io/group: "{{ .group }}"
+      platform.nukleros.io/category: "{{ .category }}"
       platform.nukleros.io/project: "{{ .project }}"
     onMissing:
       action: inject
 
   - name: "remove the helm info"
-    query: 
+    query:
       - metadata.labels["helm.sh/chart"]
       - metadata.labels["app.kubernetes.io/managed-by"]
     action: delete

--- a/.source/secrets/external-secrets/config/overlays/crds.yaml
+++ b/.source/secrets/external-secrets/config/overlays/crds.yaml
@@ -3,7 +3,7 @@ commonOverlays:
   - name: "apply nukleros labels"
     query: "metadata.labels"
     value:
-      platform.nukleros.io/group: "{{ .group }}"
+      platform.nukleros.io/category: "{{ .category }}"
       platform.nukleros.io/project: "{{ .project }}"
     onMissing:
       action: inject

--- a/.source/secrets/external-secrets/config/overlays/deployment.yaml
+++ b/.source/secrets/external-secrets/config/overlays/deployment.yaml
@@ -3,7 +3,7 @@ commonOverlays:
   - name: "apply nukleros labels"
     query: "metadata.labels"
     value:
-      platform.nukleros.io/group: "{{ .group }}"
+      platform.nukleros.io/category: "{{ .category }}"
       platform.nukleros.io/project: "{{ .project }}"
     onMissing:
       action: inject
@@ -11,7 +11,7 @@ commonOverlays:
   - name: "apply nukleros labels to pod template"
     query: "spec.template.metadata.labels"
     value:
-      platform.nukleros.io/group: "{{ .group }}"
+      platform.nukleros.io/category: "{{ .category }}"
       platform.nukleros.io/project: "{{ .project }}"
     onMissing:
       action: inject

--- a/.source/secrets/external-secrets/config/overlays/rbac.yaml
+++ b/.source/secrets/external-secrets/config/overlays/rbac.yaml
@@ -3,7 +3,7 @@ commonOverlays:
   - name: "apply nukleros labels"
     query: "metadata.labels"
     value:
-      platform.nukleros.io/group: "{{ .group }}"
+      platform.nukleros.io/category: "{{ .category }}"
       platform.nukleros.io/project: "{{ .project }}"
     onMissing:
       action: inject

--- a/.source/secrets/external-secrets/config/overlays/service.yaml
+++ b/.source/secrets/external-secrets/config/overlays/service.yaml
@@ -3,7 +3,7 @@ commonOverlays:
   - name: "apply nukleros labels"
     query: "metadata.labels"
     value:
-      platform.nukleros.io/group: "{{ .group }}"
+      platform.nukleros.io/category: "{{ .category }}"
       platform.nukleros.io/project: "{{ .project }}"
     onMissing:
       action: inject

--- a/.source/secrets/external-secrets/config/overlays/webhook.yaml
+++ b/.source/secrets/external-secrets/config/overlays/webhook.yaml
@@ -3,7 +3,7 @@ commonOverlays:
   - name: "apply nukleros labels"
     query: "metadata.labels"
     value:
-      platform.nukleros.io/group: "{{ .group }}"
+      platform.nukleros.io/category: "{{ .category }}"
       platform.nukleros.io/project: "{{ .project }}"
     onMissing:
       action: inject

--- a/.source/secrets/reloader/config/overlays/deployment.yaml
+++ b/.source/secrets/reloader/config/overlays/deployment.yaml
@@ -4,7 +4,7 @@ commonOverlays:
     query: "metadata.labels"
     value:
       app.kubernetes.io/name: "{{ .name }}"
-      platform.nukleros.io/group: "{{ .group }}"
+      platform.nukleros.io/category: "{{ .category }}"
       platform.nukleros.io/project: "{{ .project }}"
     # replace labels here to remove all of the helm info
     action: replace
@@ -15,7 +15,7 @@ commonOverlays:
     query: "spec.template.metadata.labels"
     value:
       app.kubernetes.io/name: "{{ .name }}"
-      platform.nukleros.io/group: "{{ .group }}"
+      platform.nukleros.io/category: "{{ .category }}"
       platform.nukleros.io/project: "{{ .project }}"
     # replace labels here to remove all of the helm info
     action: replace
@@ -26,7 +26,7 @@ commonOverlays:
     query: "spec.selector.matchLabels"
     value:
       app.kubernetes.io/name: "{{ .name }}"
-      platform.nukleros.io/group: "{{ .group }}"
+      platform.nukleros.io/category: "{{ .category }}"
       platform.nukleros.io/project: "{{ .project }}"
     # replace labels here to remove all of the helm info
     action: replace

--- a/.source/secrets/reloader/config/overlays/rbac.yaml
+++ b/.source/secrets/reloader/config/overlays/rbac.yaml
@@ -3,7 +3,7 @@ commonOverlays:
   - name: "apply nukleros labels"
     query: "metadata.labels"
     value:
-      platform.nukleros.io/group: "{{ .group }}"
+      platform.nukleros.io/category: "{{ .category }}"
       platform.nukleros.io/project: "{{ .project }}"
     # replace labels here to remove all of the helm info
     action: replace

--- a/.source/secrets/values.yaml
+++ b/.source/secrets/values.yaml
@@ -1,3 +1,3 @@
 ---
 namespace: nukleros-secrets-system
-group: secrets
+category: secrets

--- a/Makefile
+++ b/Makefile
@@ -17,14 +17,14 @@ yot:
 #
 # developer automation workflows
 #
-GROUP ?=
+CATEGORY ?=
 PROJECT ?=
 project:
-	@mkdir -p .source/$(GROUP)/$(PROJECT)/config/overlays .source/$(GROUP)/$(PROJECT)/static .source/$(GROUP)/$(PROJECT)/vendor $(GROUP)/$(PROJECT)
-	@touch .source/$(GROUP)/$(PROJECT)/config/vendor.yaml .source/$(GROUP)/$(PROJECT)/config/values.yaml
+	@mkdir -p .source/$(CATEGORY)/$(PROJECT)/config/overlays .source/$(CATEGORY)/$(PROJECT)/static .source/$(CATEGORY)/$(PROJECT)/vendor $(CATEGORY)/$(PROJECT)
+	@touch .source/$(CATEGORY)/$(PROJECT)/config/vendor.yaml .source/$(CATEGORY)/$(PROJECT)/config/values.yaml
 
 download:
-	@GROUP=$(GROUP) PROJECT=$(PROJECT) .scripts/download.sh
+	@CATEGORY=$(CATEGORY) PROJECT=$(PROJECT) .scripts/download.sh
 
 overlay:
-	@GROUP=$(GROUP) PROJECT=$(PROJECT) .scripts/overlay.sh
+	@CATEGORY=$(CATEGORY) PROJECT=$(PROJECT) .scripts/overlay.sh

--- a/certificates/cert-manager/crds.yaml
+++ b/certificates/cert-manager/crds.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/version: v1.9.1
-    platform.nukleros.io/group: certificates
+    platform.nukleros.io/category: certificates
     platform.nukleros.io/project: cert-manager
 spec:
   group: cert-manager.io
@@ -207,7 +207,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/version: v1.9.1
-    platform.nukleros.io/group: certificates
+    platform.nukleros.io/category: certificates
     platform.nukleros.io/project: cert-manager
 spec:
   group: cert-manager.io
@@ -580,7 +580,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/version: v1.9.1
-    platform.nukleros.io/group: certificates
+    platform.nukleros.io/category: certificates
     platform.nukleros.io/project: cert-manager
 spec:
   group: acme.cert-manager.io
@@ -1627,7 +1627,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/version: v1.9.1
-    platform.nukleros.io/group: certificates
+    platform.nukleros.io/category: certificates
     platform.nukleros.io/project: cert-manager
 spec:
   group: cert-manager.io
@@ -2889,7 +2889,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/version: v1.9.1
-    platform.nukleros.io/group: certificates
+    platform.nukleros.io/category: certificates
     platform.nukleros.io/project: cert-manager
 spec:
   group: cert-manager.io
@@ -4151,7 +4151,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/version: v1.9.1
-    platform.nukleros.io/group: certificates
+    platform.nukleros.io/category: certificates
     platform.nukleros.io/project: cert-manager
 spec:
   group: acme.cert-manager.io

--- a/certificates/cert-manager/deployment.yaml
+++ b/certificates/cert-manager/deployment.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: cainjector
     app.kubernetes.io/version: v1.9.1
-    platform.nukleros.io/group: certificates
+    platform.nukleros.io/category: certificates
     platform.nukleros.io/project: cert-manager
 spec:
   replicas: 2
@@ -26,7 +26,7 @@ spec:
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/component: cainjector
         app.kubernetes.io/version: v1.9.1
-        platform.nukleros.io/group: certificates
+        platform.nukleros.io/category: certificates
         platform.nukleros.io/project: cert-manager
     spec:
       serviceAccountName: cert-manager-cainjector
@@ -86,7 +86,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: controller
     app.kubernetes.io/version: v1.9.1
-    platform.nukleros.io/group: certificates
+    platform.nukleros.io/category: certificates
     platform.nukleros.io/project: cert-manager
 spec:
   replicas: 2
@@ -103,7 +103,7 @@ spec:
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/component: controller
         app.kubernetes.io/version: v1.9.1
-        platform.nukleros.io/group: certificates
+        platform.nukleros.io/category: certificates
         platform.nukleros.io/project: cert-manager
       annotations:
         prometheus.io/path: /metrics
@@ -172,7 +172,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: webhook
     app.kubernetes.io/version: v1.9.1
-    platform.nukleros.io/group: certificates
+    platform.nukleros.io/category: certificates
     platform.nukleros.io/project: cert-manager
 spec:
   replicas: 2
@@ -189,7 +189,7 @@ spec:
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/component: webhook
         app.kubernetes.io/version: v1.9.1
-        platform.nukleros.io/group: certificates
+        platform.nukleros.io/category: certificates
         platform.nukleros.io/project: cert-manager
     spec:
       serviceAccountName: cert-manager-webhook

--- a/certificates/cert-manager/rbac.yaml
+++ b/certificates/cert-manager/rbac.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: cainjector
     app.kubernetes.io/version: v1.9.1
-    platform.nukleros.io/group: certificates
+    platform.nukleros.io/category: certificates
     platform.nukleros.io/project: cert-manager
 ---
 apiVersion: v1
@@ -25,7 +25,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: controller
     app.kubernetes.io/version: v1.9.1
-    platform.nukleros.io/group: certificates
+    platform.nukleros.io/category: certificates
     platform.nukleros.io/project: cert-manager
 ---
 apiVersion: v1
@@ -40,7 +40,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: webhook
     app.kubernetes.io/version: v1.9.1
-    platform.nukleros.io/group: certificates
+    platform.nukleros.io/category: certificates
     platform.nukleros.io/project: cert-manager
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -53,7 +53,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: cainjector
     app.kubernetes.io/version: v1.9.1
-    platform.nukleros.io/group: certificates
+    platform.nukleros.io/category: certificates
     platform.nukleros.io/project: cert-manager
 rules:
   - apiGroups:
@@ -120,7 +120,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: controller
     app.kubernetes.io/version: v1.9.1
-    platform.nukleros.io/group: certificates
+    platform.nukleros.io/category: certificates
     platform.nukleros.io/project: cert-manager
 rules:
   - apiGroups:
@@ -168,7 +168,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: controller
     app.kubernetes.io/version: v1.9.1
-    platform.nukleros.io/group: certificates
+    platform.nukleros.io/category: certificates
     platform.nukleros.io/project: cert-manager
 rules:
   - apiGroups:
@@ -216,7 +216,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: controller
     app.kubernetes.io/version: v1.9.1
-    platform.nukleros.io/group: certificates
+    platform.nukleros.io/category: certificates
     platform.nukleros.io/project: cert-manager
 rules:
   - apiGroups:
@@ -287,7 +287,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: controller
     app.kubernetes.io/version: v1.9.1
-    platform.nukleros.io/group: certificates
+    platform.nukleros.io/category: certificates
     platform.nukleros.io/project: cert-manager
 rules:
   - apiGroups:
@@ -355,7 +355,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: controller
     app.kubernetes.io/version: v1.9.1
-    platform.nukleros.io/group: certificates
+    platform.nukleros.io/category: certificates
     platform.nukleros.io/project: cert-manager
 rules:
   - apiGroups:
@@ -462,7 +462,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: controller
     app.kubernetes.io/version: v1.9.1
-    platform.nukleros.io/group: certificates
+    platform.nukleros.io/category: certificates
     platform.nukleros.io/project: cert-manager
 rules:
   - apiGroups:
@@ -536,7 +536,7 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
-    platform.nukleros.io/group: certificates
+    platform.nukleros.io/category: certificates
     platform.nukleros.io/project: cert-manager
 rules:
   - apiGroups:
@@ -571,7 +571,7 @@ metadata:
     app.kubernetes.io/version: v1.9.1
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
-    platform.nukleros.io/group: certificates
+    platform.nukleros.io/category: certificates
     platform.nukleros.io/project: cert-manager
 rules:
   - apiGroups:
@@ -614,7 +614,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: cert-manager
     app.kubernetes.io/version: v1.9.1
-    platform.nukleros.io/group: certificates
+    platform.nukleros.io/category: certificates
     platform.nukleros.io/project: cert-manager
 rules:
   - apiGroups:
@@ -637,7 +637,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: cert-manager
     app.kubernetes.io/version: v1.9.1
-    platform.nukleros.io/group: certificates
+    platform.nukleros.io/category: certificates
     platform.nukleros.io/project: cert-manager
 rules:
   - apiGroups:
@@ -682,7 +682,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: webhook
     app.kubernetes.io/version: v1.9.1
-    platform.nukleros.io/group: certificates
+    platform.nukleros.io/category: certificates
     platform.nukleros.io/project: cert-manager
 rules:
   - apiGroups:
@@ -702,7 +702,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: cainjector
     app.kubernetes.io/version: v1.9.1
-    platform.nukleros.io/group: certificates
+    platform.nukleros.io/category: certificates
     platform.nukleros.io/project: cert-manager
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -723,7 +723,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: controller
     app.kubernetes.io/version: v1.9.1
-    platform.nukleros.io/group: certificates
+    platform.nukleros.io/category: certificates
     platform.nukleros.io/project: cert-manager
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -744,7 +744,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: controller
     app.kubernetes.io/version: v1.9.1
-    platform.nukleros.io/group: certificates
+    platform.nukleros.io/category: certificates
     platform.nukleros.io/project: cert-manager
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -765,7 +765,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: controller
     app.kubernetes.io/version: v1.9.1
-    platform.nukleros.io/group: certificates
+    platform.nukleros.io/category: certificates
     platform.nukleros.io/project: cert-manager
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -786,7 +786,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: controller
     app.kubernetes.io/version: v1.9.1
-    platform.nukleros.io/group: certificates
+    platform.nukleros.io/category: certificates
     platform.nukleros.io/project: cert-manager
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -807,7 +807,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: controller
     app.kubernetes.io/version: v1.9.1
-    platform.nukleros.io/group: certificates
+    platform.nukleros.io/category: certificates
     platform.nukleros.io/project: cert-manager
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -828,7 +828,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: controller
     app.kubernetes.io/version: v1.9.1
-    platform.nukleros.io/group: certificates
+    platform.nukleros.io/category: certificates
     platform.nukleros.io/project: cert-manager
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -849,7 +849,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: cert-manager
     app.kubernetes.io/version: v1.9.1
-    platform.nukleros.io/group: certificates
+    platform.nukleros.io/category: certificates
     platform.nukleros.io/project: cert-manager
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -870,7 +870,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: cert-manager
     app.kubernetes.io/version: v1.9.1
-    platform.nukleros.io/group: certificates
+    platform.nukleros.io/category: certificates
     platform.nukleros.io/project: cert-manager
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -891,7 +891,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: webhook
     app.kubernetes.io/version: v1.9.1
-    platform.nukleros.io/group: certificates
+    platform.nukleros.io/category: certificates
     platform.nukleros.io/project: cert-manager
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -914,7 +914,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: cainjector
     app.kubernetes.io/version: v1.9.1
-    platform.nukleros.io/group: certificates
+    platform.nukleros.io/category: certificates
     platform.nukleros.io/project: cert-manager
 rules:
   - apiGroups:
@@ -946,7 +946,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: controller
     app.kubernetes.io/version: v1.9.1
-    platform.nukleros.io/group: certificates
+    platform.nukleros.io/category: certificates
     platform.nukleros.io/project: cert-manager
 rules:
   - apiGroups:
@@ -977,7 +977,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: webhook
     app.kubernetes.io/version: v1.9.1
-    platform.nukleros.io/group: certificates
+    platform.nukleros.io/category: certificates
     platform.nukleros.io/project: cert-manager
 rules:
   - apiGroups:
@@ -1009,7 +1009,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: cainjector
     app.kubernetes.io/version: v1.9.1
-    platform.nukleros.io/group: certificates
+    platform.nukleros.io/category: certificates
     platform.nukleros.io/project: cert-manager
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -1031,7 +1031,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: controller
     app.kubernetes.io/version: v1.9.1
-    platform.nukleros.io/group: certificates
+    platform.nukleros.io/category: certificates
     platform.nukleros.io/project: cert-manager
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -1054,7 +1054,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: webhook
     app.kubernetes.io/version: v1.9.1
-    platform.nukleros.io/group: certificates
+    platform.nukleros.io/category: certificates
     platform.nukleros.io/project: cert-manager
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/certificates/cert-manager/service.yaml
+++ b/certificates/cert-manager/service.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: controller
     app.kubernetes.io/version: v1.9.1
-    platform.nukleros.io/group: certificates
+    platform.nukleros.io/category: certificates
     platform.nukleros.io/project: cert-manager
 spec:
   type: ClusterIP
@@ -34,7 +34,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: webhook
     app.kubernetes.io/version: v1.9.1
-    platform.nukleros.io/group: certificates
+    platform.nukleros.io/category: certificates
     platform.nukleros.io/project: cert-manager
 spec:
   type: ClusterIP

--- a/certificates/cert-manager/webhook.yaml
+++ b/certificates/cert-manager/webhook.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: webhook
     app.kubernetes.io/version: v1.9.1
-    platform.nukleros.io/group: certificates
+    platform.nukleros.io/category: certificates
     platform.nukleros.io/project: cert-manager
   annotations:
     cert-manager.io/inject-ca-from-secret: nukleros-certs-system/cert-manager-webhook-ca
@@ -47,7 +47,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: webhook
     app.kubernetes.io/version: v1.9.1
-    platform.nukleros.io/group: certificates
+    platform.nukleros.io/category: certificates
     platform.nukleros.io/project: cert-manager
   annotations:
     cert-manager.io/inject-ca-from-secret: nukleros-certs-system/cert-manager-webhook-ca

--- a/ingress/external-dns/config-active-directory.yaml
+++ b/ingress/external-dns/config-active-directory.yaml
@@ -5,7 +5,7 @@ metadata:
   name: external-dns-active-directory
   namespace: nukleros-ingress-system
   labels:
-    platform.nukleros.io/group: ingress
+    platform.nukleros.io/category: ingress
     platform.nukleros.io/project: external-dns
 stringData:
   EXTERNAL_DNS_TXT_OWNER_ID: external-dns-
@@ -28,7 +28,7 @@ metadata:
   name: external-dns-active-directory-kerberos
   namespace: nukleros-ingress-system
   labels:
-    platform.nukleros.io/group: ingress
+    platform.nukleros.io/category: ingress
     platform.nukleros.io/project: external-dns
 data:
   krb5.conf: |

--- a/ingress/external-dns/config-google.yaml
+++ b/ingress/external-dns/config-google.yaml
@@ -5,7 +5,7 @@ metadata:
   name: external-dns-google
   namespace: nukleros-ingress-system
   labels:
-    platform.nukleros.io/group: ingress
+    platform.nukleros.io/category: ingress
     platform.nukleros.io/project: external-dns
 stringData:
   EXTERNAL_DNS_TXT_OWNER_ID: external-dns-

--- a/ingress/external-dns/config-route53.yaml
+++ b/ingress/external-dns/config-route53.yaml
@@ -5,7 +5,7 @@ metadata:
   name: external-dns-route53
   namespace: nukleros-ingress-system
   labels:
-    platform.nukleros.io/group: ingress
+    platform.nukleros.io/category: ingress
     platform.nukleros.io/project: external-dns
 stringData:
   EXTERNAL_DNS_TXT_OWNER_ID: external-dns-

--- a/ingress/external-dns/deployment-active-directory.yaml
+++ b/ingress/external-dns/deployment-active-directory.yaml
@@ -7,7 +7,7 @@ metadata:
     app: external-dns-active-directory
     app.kubernetes.io/name: external-dns-active-directory
     app.kubernetes.io/instance: external-dns
-    platform.nukleros.io/group: ingress
+    platform.nukleros.io/category: ingress
     platform.nukleros.io/project: external-dns
   namespace: nukleros-ingress-system
 spec:
@@ -22,7 +22,7 @@ spec:
         app: external-dns-active-directory
         app.kubernetes.io/name: external-dns-active-directory
         app.kubernetes.io/instance: external-dns
-        platform.nukleros.io/group: ingress
+        platform.nukleros.io/category: ingress
         platform.nukleros.io/project: external-dns
     spec:
       serviceAccountName: external-dns

--- a/ingress/external-dns/deployment-google.yaml
+++ b/ingress/external-dns/deployment-google.yaml
@@ -7,7 +7,7 @@ metadata:
     app: external-dns-google
     app.kubernetes.io/name: external-dns-google
     app.kubernetes.io/instance: external-dns
-    platform.nukleros.io/group: ingress
+    platform.nukleros.io/category: ingress
     platform.nukleros.io/project: external-dns
   namespace: nukleros-ingress-system
 spec:
@@ -22,7 +22,7 @@ spec:
         app: external-dns-google
         app.kubernetes.io/name: external-dns-google
         app.kubernetes.io/instance: external-dns
-        platform.nukleros.io/group: ingress
+        platform.nukleros.io/category: ingress
         platform.nukleros.io/project: external-dns
     spec:
       serviceAccountName: external-dns

--- a/ingress/external-dns/deployment-route53.yaml
+++ b/ingress/external-dns/deployment-route53.yaml
@@ -7,7 +7,7 @@ metadata:
     app: external-dns-route53
     app.kubernetes.io/name: external-dns-route53
     app.kubernetes.io/instance: external-dns
-    platform.nukleros.io/group: ingress
+    platform.nukleros.io/category: ingress
     platform.nukleros.io/project: external-dns
   namespace: nukleros-ingress-system
 spec:
@@ -22,7 +22,7 @@ spec:
         app: external-dns-route53
         app.kubernetes.io/name: external-dns-route53
         app.kubernetes.io/instance: external-dns
-        platform.nukleros.io/group: ingress
+        platform.nukleros.io/category: ingress
         platform.nukleros.io/project: external-dns
     spec:
       serviceAccountName: external-dns

--- a/ingress/external-dns/rbac.yaml
+++ b/ingress/external-dns/rbac.yaml
@@ -1,10 +1,26 @@
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: external-dns-viewer
+  labels:
+    platform.nukleros.io/category: ingress
+    platform.nukleros.io/project: external-dns
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: external-dns
+subjects:
+  - kind: ServiceAccount
+    name: external-dns
+    namespace: nukleros-ingress-system
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: external-dns
   labels:
-    platform.nukleros.io/group: ingress
+    platform.nukleros.io/category: ingress
     platform.nukleros.io/project: external-dns
   namespace: nukleros-ingress-system
 ---
@@ -13,7 +29,7 @@ kind: ClusterRole
 metadata:
   name: external-dns
   labels:
-    platform.nukleros.io/group: ingress
+    platform.nukleros.io/category: ingress
     platform.nukleros.io/project: external-dns
   namespace: nukleros-ingress-system
 rules:
@@ -50,19 +66,3 @@ rules:
     verbs:
       - watch
       - list
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: external-dns-viewer
-  labels:
-    platform.nukleros.io/group: ingress
-    platform.nukleros.io/project: external-dns
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: external-dns
-subjects:
-  - kind: ServiceAccount
-    name: external-dns
-    namespace: nukleros-ingress-system

--- a/ingress/kong/crds.yaml
+++ b/ingress/kong/crds.yaml
@@ -5,7 +5,7 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.7.0
   name: kongclusterplugins.configuration.konghq.com
   labels:
-    platform.nukleros.io/group: ingress
+    platform.nukleros.io/category: ingress
     platform.nukleros.io/project: kong-ingress-controller
 spec:
   group: configuration.konghq.com
@@ -127,7 +127,7 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.7.0
   name: kongconsumers.configuration.konghq.com
   labels:
-    platform.nukleros.io/group: ingress
+    platform.nukleros.io/category: ingress
     platform.nukleros.io/project: kong-ingress-controller
 spec:
   group: configuration.konghq.com
@@ -194,7 +194,7 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.7.0
   name: kongingresses.configuration.konghq.com
   labels:
-    platform.nukleros.io/group: ingress
+    platform.nukleros.io/category: ingress
     platform.nukleros.io/project: kong-ingress-controller
 spec:
   group: configuration.konghq.com
@@ -469,7 +469,7 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.7.0
   name: kongplugins.configuration.konghq.com
   labels:
-    platform.nukleros.io/group: ingress
+    platform.nukleros.io/category: ingress
     platform.nukleros.io/project: kong-ingress-controller
 spec:
   group: configuration.konghq.com
@@ -587,7 +587,7 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.7.0
   name: tcpingresses.configuration.konghq.com
   labels:
-    platform.nukleros.io/group: ingress
+    platform.nukleros.io/category: ingress
     platform.nukleros.io/project: kong-ingress-controller
 spec:
   group: configuration.konghq.com
@@ -738,7 +738,7 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.7.0
   name: udpingresses.configuration.konghq.com
   labels:
-    platform.nukleros.io/group: ingress
+    platform.nukleros.io/category: ingress
     platform.nukleros.io/project: kong-ingress-controller
 spec:
   group: configuration.konghq.com

--- a/ingress/kong/deployment.yaml
+++ b/ingress/kong/deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   labels:
     app: ingress-kong
-    platform.nukleros.io/group: ingress
+    platform.nukleros.io/category: ingress
     platform.nukleros.io/project: kong-ingress-controller
     app.kubernetes.io/name: kong-ingress
   name: ingress-kong
@@ -21,7 +21,7 @@ spec:
         traffic.sidecar.istio.io/includeInboundPorts: ""
       labels:
         app: ingress-kong
-        platform.nukleros.io/group: ingress
+        platform.nukleros.io/category: ingress
         platform.nukleros.io/project: kong-ingress-controller
     spec:
       automountServiceAccountToken: false

--- a/ingress/kong/ingress-class.yaml
+++ b/ingress/kong/ingress-class.yaml
@@ -3,7 +3,7 @@ kind: IngressClass
 metadata:
   name: kong
   labels:
-    platform.nukleros.io/group: ingress
+    platform.nukleros.io/category: ingress
     platform.nukleros.io/project: kong-ingress-controller
 spec:
   controller: ingress-controllers.konghq.com/kong

--- a/ingress/kong/rbac.yaml
+++ b/ingress/kong/rbac.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kong-serviceaccount
   namespace: nukleros-ingress-system
   labels:
-    platform.nukleros.io/group: ingress
+    platform.nukleros.io/category: ingress
     platform.nukleros.io/project: kong-ingress-controller
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -13,7 +13,7 @@ metadata:
   name: kong-leader-election
   namespace: nukleros-ingress-system
   labels:
-    platform.nukleros.io/group: ingress
+    platform.nukleros.io/category: ingress
     platform.nukleros.io/project: kong-ingress-controller
 rules:
   - apiGroups:
@@ -43,7 +43,7 @@ kind: ClusterRole
 metadata:
   name: kong-ingress
   labels:
-    platform.nukleros.io/group: ingress
+    platform.nukleros.io/category: ingress
     platform.nukleros.io/project: kong-ingress-controller
 rules:
   - apiGroups:
@@ -390,7 +390,7 @@ metadata:
   name: kong-leader-election
   namespace: nukleros-ingress-system
   labels:
-    platform.nukleros.io/group: ingress
+    platform.nukleros.io/category: ingress
     platform.nukleros.io/project: kong-ingress-controller
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -406,7 +406,7 @@ kind: ClusterRoleBinding
 metadata:
   name: kong-ingress
   labels:
-    platform.nukleros.io/group: ingress
+    platform.nukleros.io/category: ingress
     platform.nukleros.io/project: kong-ingress-controller
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/ingress/kong/service.yaml
+++ b/ingress/kong/service.yaml
@@ -7,7 +7,7 @@ metadata:
   name: kong-proxy
   namespace: nukleros-ingress-system
   labels:
-    platform.nukleros.io/group: ingress
+    platform.nukleros.io/category: ingress
     platform.nukleros.io/project: kong-ingress-controller
 spec:
   ports:
@@ -29,7 +29,7 @@ metadata:
   name: kong-validation-webhook
   namespace: nukleros-ingress-system
   labels:
-    platform.nukleros.io/group: ingress
+    platform.nukleros.io/category: ingress
     platform.nukleros.io/project: kong-ingress-controller
 spec:
   ports:

--- a/ingress/nginx/config.yaml
+++ b/ingress/nginx/config.yaml
@@ -5,6 +5,6 @@ metadata:
   name: nginx-config
   namespace: nukleros-ingress-system
   labels:
-    platform.nukleros.io/group: ingress
+    platform.nukleros.io/category: ingress
     platform.nukleros.io/project: nginx-ingress-controller
 data:

--- a/ingress/nginx/crds.yaml
+++ b/ingress/nginx/crds.yaml
@@ -7,7 +7,7 @@ metadata:
   creationTimestamp: null
   name: dnsendpoints.externaldns.nginx.org
   labels:
-    platform.nukleros.io/group: ingress
+    platform.nukleros.io/category: ingress
     platform.nukleros.io/project: nginx-ingress-controller
 spec:
   group: externaldns.nginx.org
@@ -98,7 +98,7 @@ metadata:
   creationTimestamp: null
   name: transportservers.k8s.nginx.org
   labels:
-    platform.nukleros.io/group: ingress
+    platform.nukleros.io/category: ingress
     platform.nukleros.io/project: nginx-ingress-controller
 spec:
   group: k8s.nginx.org
@@ -257,309 +257,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
-  name: policies.k8s.nginx.org
-  labels:
-    platform.nukleros.io/group: ingress
-    platform.nukleros.io/project: nginx-ingress-controller
-spec:
-  group: k8s.nginx.org
-  names:
-    kind: Policy
-    listKind: PolicyList
-    plural: policies
-    shortNames:
-      - pol
-    singular: policy
-  scope: Namespaced
-  versions:
-    - additionalPrinterColumns:
-        - description: Current state of the Policy. If the resource has a valid status, it means it has been validated and accepted by the Ingress Controller.
-          jsonPath: .status.state
-          name: State
-          type: string
-        - jsonPath: .metadata.creationTimestamp
-          name: Age
-          type: date
-      name: v1
-      schema:
-        openAPIV3Schema:
-          description: Policy defines a Policy for VirtualServer and VirtualServerRoute resources.
-          type: object
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: PolicySpec is the spec of the Policy resource. The spec includes multiple fields, where each field represents a different policy. Only one policy (field) is allowed.
-              type: object
-              properties:
-                accessControl:
-                  description: AccessControl defines an access policy based on the source IP of a request.
-                  type: object
-                  properties:
-                    allow:
-                      type: array
-                      items:
-                        type: string
-                    deny:
-                      type: array
-                      items:
-                        type: string
-                basicAuth:
-                  description: 'BasicAuth holds HTTP Basic authentication configuration policy status: preview'
-                  type: object
-                  properties:
-                    realm:
-                      type: string
-                    secret:
-                      type: string
-                egressMTLS:
-                  description: EgressMTLS defines an Egress MTLS policy.
-                  type: object
-                  properties:
-                    ciphers:
-                      type: string
-                    protocols:
-                      type: string
-                    serverName:
-                      type: boolean
-                    sessionReuse:
-                      type: boolean
-                    sslName:
-                      type: string
-                    tlsSecret:
-                      type: string
-                    trustedCertSecret:
-                      type: string
-                    verifyDepth:
-                      type: integer
-                    verifyServer:
-                      type: boolean
-                ingressClassName:
-                  type: string
-                ingressMTLS:
-                  description: IngressMTLS defines an Ingress MTLS policy.
-                  type: object
-                  properties:
-                    clientCertSecret:
-                      type: string
-                    verifyClient:
-                      type: string
-                    verifyDepth:
-                      type: integer
-                jwt:
-                  description: JWTAuth holds JWT authentication configuration.
-                  type: object
-                  properties:
-                    realm:
-                      type: string
-                    secret:
-                      type: string
-                    token:
-                      type: string
-                oidc:
-                  description: OIDC defines an Open ID Connect policy.
-                  type: object
-                  properties:
-                    authEndpoint:
-                      type: string
-                    clientID:
-                      type: string
-                    clientSecret:
-                      type: string
-                    jwksURI:
-                      type: string
-                    redirectURI:
-                      type: string
-                    scope:
-                      type: string
-                    tokenEndpoint:
-                      type: string
-                    zoneSyncLeeway:
-                      type: integer
-                rateLimit:
-                  description: RateLimit defines a rate limit policy.
-                  type: object
-                  properties:
-                    burst:
-                      type: integer
-                    delay:
-                      type: integer
-                    dryRun:
-                      type: boolean
-                    key:
-                      type: string
-                    logLevel:
-                      type: string
-                    noDelay:
-                      type: boolean
-                    rate:
-                      type: string
-                    rejectCode:
-                      type: integer
-                    zoneSize:
-                      type: string
-                waf:
-                  description: WAF defines an WAF policy.
-                  type: object
-                  properties:
-                    apPolicy:
-                      type: string
-                    enable:
-                      type: boolean
-                    securityLog:
-                      description: SecurityLog defines the security log of a WAF policy.
-                      type: object
-                      properties:
-                        apLogConf:
-                          type: string
-                        enable:
-                          type: boolean
-                        logDest:
-                          type: string
-                    securityLogs:
-                      type: array
-                      items:
-                        description: SecurityLog defines the security log of a WAF policy.
-                        type: object
-                        properties:
-                          apLogConf:
-                            type: string
-                          enable:
-                            type: boolean
-                          logDest:
-                            type: string
-            status:
-              description: PolicyStatus is the status of the policy resource
-              type: object
-              properties:
-                message:
-                  type: string
-                reason:
-                  type: string
-                state:
-                  type: string
-      served: true
-      storage: true
-      subresources:
-        status: {}
-    - name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: Policy defines a Policy for VirtualServer and VirtualServerRoute resources.
-          type: object
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: PolicySpec is the spec of the Policy resource. The spec includes multiple fields, where each field represents a different policy. Only one policy (field) is allowed.
-              type: object
-              properties:
-                accessControl:
-                  description: AccessControl defines an access policy based on the source IP of a request.
-                  type: object
-                  properties:
-                    allow:
-                      type: array
-                      items:
-                        type: string
-                    deny:
-                      type: array
-                      items:
-                        type: string
-                egressMTLS:
-                  description: EgressMTLS defines an Egress MTLS policy.
-                  type: object
-                  properties:
-                    ciphers:
-                      type: string
-                    protocols:
-                      type: string
-                    serverName:
-                      type: boolean
-                    sessionReuse:
-                      type: boolean
-                    sslName:
-                      type: string
-                    tlsSecret:
-                      type: string
-                    trustedCertSecret:
-                      type: string
-                    verifyDepth:
-                      type: integer
-                    verifyServer:
-                      type: boolean
-                ingressMTLS:
-                  description: IngressMTLS defines an Ingress MTLS policy.
-                  type: object
-                  properties:
-                    clientCertSecret:
-                      type: string
-                    verifyClient:
-                      type: string
-                    verifyDepth:
-                      type: integer
-                jwt:
-                  description: JWTAuth holds JWT authentication configuration.
-                  type: object
-                  properties:
-                    realm:
-                      type: string
-                    secret:
-                      type: string
-                    token:
-                      type: string
-                rateLimit:
-                  description: RateLimit defines a rate limit policy.
-                  type: object
-                  properties:
-                    burst:
-                      type: integer
-                    delay:
-                      type: integer
-                    dryRun:
-                      type: boolean
-                    key:
-                      type: string
-                    logLevel:
-                      type: string
-                    noDelay:
-                      type: boolean
-                    rate:
-                      type: string
-                    rejectCode:
-                      type: integer
-                    zoneSize:
-                      type: string
-      served: true
-      storage: false
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
-  creationTimestamp: null
   name: virtualserverroutes.k8s.nginx.org
   labels:
-    platform.nukleros.io/group: ingress
+    platform.nukleros.io/category: ingress
     platform.nukleros.io/project: nginx-ingress-controller
 spec:
   group: k8s.nginx.org
@@ -1202,9 +902,309 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
+  name: policies.k8s.nginx.org
+  labels:
+    platform.nukleros.io/category: ingress
+    platform.nukleros.io/project: nginx-ingress-controller
+spec:
+  group: k8s.nginx.org
+  names:
+    kind: Policy
+    listKind: PolicyList
+    plural: policies
+    shortNames:
+      - pol
+    singular: policy
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - description: Current state of the Policy. If the resource has a valid status, it means it has been validated and accepted by the Ingress Controller.
+          jsonPath: .status.state
+          name: State
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: Policy defines a Policy for VirtualServer and VirtualServerRoute resources.
+          type: object
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: PolicySpec is the spec of the Policy resource. The spec includes multiple fields, where each field represents a different policy. Only one policy (field) is allowed.
+              type: object
+              properties:
+                accessControl:
+                  description: AccessControl defines an access policy based on the source IP of a request.
+                  type: object
+                  properties:
+                    allow:
+                      type: array
+                      items:
+                        type: string
+                    deny:
+                      type: array
+                      items:
+                        type: string
+                basicAuth:
+                  description: 'BasicAuth holds HTTP Basic authentication configuration policy status: preview'
+                  type: object
+                  properties:
+                    realm:
+                      type: string
+                    secret:
+                      type: string
+                egressMTLS:
+                  description: EgressMTLS defines an Egress MTLS policy.
+                  type: object
+                  properties:
+                    ciphers:
+                      type: string
+                    protocols:
+                      type: string
+                    serverName:
+                      type: boolean
+                    sessionReuse:
+                      type: boolean
+                    sslName:
+                      type: string
+                    tlsSecret:
+                      type: string
+                    trustedCertSecret:
+                      type: string
+                    verifyDepth:
+                      type: integer
+                    verifyServer:
+                      type: boolean
+                ingressClassName:
+                  type: string
+                ingressMTLS:
+                  description: IngressMTLS defines an Ingress MTLS policy.
+                  type: object
+                  properties:
+                    clientCertSecret:
+                      type: string
+                    verifyClient:
+                      type: string
+                    verifyDepth:
+                      type: integer
+                jwt:
+                  description: JWTAuth holds JWT authentication configuration.
+                  type: object
+                  properties:
+                    realm:
+                      type: string
+                    secret:
+                      type: string
+                    token:
+                      type: string
+                oidc:
+                  description: OIDC defines an Open ID Connect policy.
+                  type: object
+                  properties:
+                    authEndpoint:
+                      type: string
+                    clientID:
+                      type: string
+                    clientSecret:
+                      type: string
+                    jwksURI:
+                      type: string
+                    redirectURI:
+                      type: string
+                    scope:
+                      type: string
+                    tokenEndpoint:
+                      type: string
+                    zoneSyncLeeway:
+                      type: integer
+                rateLimit:
+                  description: RateLimit defines a rate limit policy.
+                  type: object
+                  properties:
+                    burst:
+                      type: integer
+                    delay:
+                      type: integer
+                    dryRun:
+                      type: boolean
+                    key:
+                      type: string
+                    logLevel:
+                      type: string
+                    noDelay:
+                      type: boolean
+                    rate:
+                      type: string
+                    rejectCode:
+                      type: integer
+                    zoneSize:
+                      type: string
+                waf:
+                  description: WAF defines an WAF policy.
+                  type: object
+                  properties:
+                    apPolicy:
+                      type: string
+                    enable:
+                      type: boolean
+                    securityLog:
+                      description: SecurityLog defines the security log of a WAF policy.
+                      type: object
+                      properties:
+                        apLogConf:
+                          type: string
+                        enable:
+                          type: boolean
+                        logDest:
+                          type: string
+                    securityLogs:
+                      type: array
+                      items:
+                        description: SecurityLog defines the security log of a WAF policy.
+                        type: object
+                        properties:
+                          apLogConf:
+                            type: string
+                          enable:
+                            type: boolean
+                          logDest:
+                            type: string
+            status:
+              description: PolicyStatus is the status of the policy resource
+              type: object
+              properties:
+                message:
+                  type: string
+                reason:
+                  type: string
+                state:
+                  type: string
+      served: true
+      storage: true
+      subresources:
+        status: {}
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: Policy defines a Policy for VirtualServer and VirtualServerRoute resources.
+          type: object
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: PolicySpec is the spec of the Policy resource. The spec includes multiple fields, where each field represents a different policy. Only one policy (field) is allowed.
+              type: object
+              properties:
+                accessControl:
+                  description: AccessControl defines an access policy based on the source IP of a request.
+                  type: object
+                  properties:
+                    allow:
+                      type: array
+                      items:
+                        type: string
+                    deny:
+                      type: array
+                      items:
+                        type: string
+                egressMTLS:
+                  description: EgressMTLS defines an Egress MTLS policy.
+                  type: object
+                  properties:
+                    ciphers:
+                      type: string
+                    protocols:
+                      type: string
+                    serverName:
+                      type: boolean
+                    sessionReuse:
+                      type: boolean
+                    sslName:
+                      type: string
+                    tlsSecret:
+                      type: string
+                    trustedCertSecret:
+                      type: string
+                    verifyDepth:
+                      type: integer
+                    verifyServer:
+                      type: boolean
+                ingressMTLS:
+                  description: IngressMTLS defines an Ingress MTLS policy.
+                  type: object
+                  properties:
+                    clientCertSecret:
+                      type: string
+                    verifyClient:
+                      type: string
+                    verifyDepth:
+                      type: integer
+                jwt:
+                  description: JWTAuth holds JWT authentication configuration.
+                  type: object
+                  properties:
+                    realm:
+                      type: string
+                    secret:
+                      type: string
+                    token:
+                      type: string
+                rateLimit:
+                  description: RateLimit defines a rate limit policy.
+                  type: object
+                  properties:
+                    burst:
+                      type: integer
+                    delay:
+                      type: integer
+                    dryRun:
+                      type: boolean
+                    key:
+                      type: string
+                    logLevel:
+                      type: string
+                    noDelay:
+                      type: boolean
+                    rate:
+                      type: string
+                    rejectCode:
+                      type: integer
+                    zoneSize:
+                      type: string
+      served: true
+      storage: false
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.8.0
+  creationTimestamp: null
   name: globalconfigurations.k8s.nginx.org
   labels:
-    platform.nukleros.io/group: ingress
+    platform.nukleros.io/category: ingress
     platform.nukleros.io/project: nginx-ingress-controller
 spec:
   group: k8s.nginx.org
@@ -1264,7 +1264,7 @@ metadata:
   creationTimestamp: null
   name: virtualservers.k8s.nginx.org
   labels:
-    platform.nukleros.io/group: ingress
+    platform.nukleros.io/category: ingress
     platform.nukleros.io/project: nginx-ingress-controller
 spec:
   group: k8s.nginx.org

--- a/ingress/nginx/deployment.yaml
+++ b/ingress/nginx/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   name: nginx-ingress
   namespace: nukleros-ingress-system
   labels:
-    platform.nukleros.io/group: ingress
+    platform.nukleros.io/category: ingress
     platform.nukleros.io/project: nginx-ingress-controller
     app.kubernetes.io/name: nginx-ingress
 spec:
@@ -17,7 +17,7 @@ spec:
     metadata:
       labels:
         app: nginx-ingress
-        platform.nukleros.io/group: ingress
+        platform.nukleros.io/category: ingress
         platform.nukleros.io/project: nginx-ingress-controller
         app.kubernetes.io/name: nginx-ingress
       annotations:

--- a/ingress/nginx/ingress-class.yaml
+++ b/ingress/nginx/ingress-class.yaml
@@ -4,7 +4,7 @@ kind: IngressClass
 metadata:
   name: nginx
   labels:
-    platform.nukleros.io/group: ingress
+    platform.nukleros.io/category: ingress
     platform.nukleros.io/project: nginx-ingress-controller
 spec:
   controller: nginx.org/ingress-controller

--- a/ingress/nginx/rbac.yaml
+++ b/ingress/nginx/rbac.yaml
@@ -1,18 +1,10 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: nginx-ingress
-  namespace: nukleros-ingress-system
-  labels:
-    platform.nukleros.io/group: ingress
-    platform.nukleros.io/project: nginx-ingress-controller
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: nginx-ingress
   labels:
-    platform.nukleros.io/group: ingress
+    platform.nukleros.io/category: ingress
     platform.nukleros.io/project: nginx-ingress-controller
 rules:
   - apiGroups:
@@ -141,7 +133,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: nginx-ingress
   labels:
-    platform.nukleros.io/group: ingress
+    platform.nukleros.io/category: ingress
     platform.nukleros.io/project: nginx-ingress-controller
 subjects:
   - kind: ServiceAccount
@@ -151,3 +143,11 @@ roleRef:
   kind: ClusterRole
   name: nginx-ingress
   apiGroup: rbac.authorization.k8s.io
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nginx-ingress
+  namespace: nukleros-ingress-system
+  labels:
+    platform.nukleros.io/category: ingress
+    platform.nukleros.io/project: nginx-ingress-controller

--- a/ingress/nginx/secret.yaml
+++ b/ingress/nginx/secret.yaml
@@ -5,7 +5,7 @@ metadata:
   name: default-server-secret
   namespace: nukleros-ingress-system
   labels:
-    platform.nukleros.io/group: ingress
+    platform.nukleros.io/category: ingress
     platform.nukleros.io/project: nginx-ingress-controller
 type: kubernetes.io/tls
 data:

--- a/ingress/nginx/service-aws.yaml
+++ b/ingress/nginx/service-aws.yaml
@@ -8,7 +8,7 @@ metadata:
     service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp
     service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: '*'
   labels:
-    platform.nukleros.io/group: ingress
+    platform.nukleros.io/category: ingress
     platform.nukleros.io/project: nginx-ingress-controller
 spec:
   type: LoadBalancer

--- a/ingress/nginx/service-gcp-azure.yaml
+++ b/ingress/nginx/service-gcp-azure.yaml
@@ -5,7 +5,7 @@ metadata:
   name: nginx-ingress-gcp-azure
   namespace: nukleros-ingress-system
   labels:
-    platform.nukleros.io/group: ingress
+    platform.nukleros.io/category: ingress
     platform.nukleros.io/project: nginx-ingress-controller
 spec:
   externalTrafficPolicy: Local

--- a/secrets/external-secrets/config.yaml
+++ b/secrets/external-secrets/config.yaml
@@ -8,5 +8,5 @@ metadata:
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/version: v0.5.9
     external-secrets.io/component: webhook
-    platform.nukleros.io/group: secrets
+    platform.nukleros.io/category: secrets
     platform.nukleros.io/project: external-secrets

--- a/secrets/external-secrets/crds.yaml
+++ b/secrets/external-secrets/crds.yaml
@@ -5,7 +5,7 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.9.2
   name: clusterexternalsecrets.external-secrets.io
   labels:
-    platform.nukleros.io/group: secrets
+    platform.nukleros.io/category: secrets
     platform.nukleros.io/project: external-secrets
 spec:
   group: external-secrets.io
@@ -382,7 +382,7 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.9.2
   name: clustersecretstores.external-secrets.io
   labels:
-    platform.nukleros.io/group: secrets
+    platform.nukleros.io/category: secrets
     platform.nukleros.io/project: external-secrets
 spec:
   group: external-secrets.io
@@ -2562,7 +2562,7 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.9.2
   name: externalsecrets.external-secrets.io
   labels:
-    platform.nukleros.io/group: secrets
+    platform.nukleros.io/category: secrets
     platform.nukleros.io/project: external-secrets
 spec:
   group: external-secrets.io
@@ -3103,7 +3103,7 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.9.2
   name: secretstores.external-secrets.io
   labels:
-    platform.nukleros.io/group: secrets
+    platform.nukleros.io/category: secrets
     platform.nukleros.io/project: external-secrets
 spec:
   group: external-secrets.io

--- a/secrets/external-secrets/deployment.yaml
+++ b/secrets/external-secrets/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/name: external-secrets-cert-controller
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/version: v0.5.9
-    platform.nukleros.io/group: secrets
+    platform.nukleros.io/category: secrets
     platform.nukleros.io/project: external-secrets
 spec:
   replicas: 1
@@ -20,7 +20,7 @@ spec:
       labels:
         app.kubernetes.io/name: external-secrets-cert-controller
         app.kubernetes.io/instance: external-secrets
-        platform.nukleros.io/group: secrets
+        platform.nukleros.io/category: secrets
         platform.nukleros.io/project: external-secrets
     spec:
       serviceAccountName: external-secrets-cert-controller
@@ -84,7 +84,7 @@ metadata:
     app.kubernetes.io/name: external-secrets
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/version: v0.5.9
-    platform.nukleros.io/group: secrets
+    platform.nukleros.io/category: secrets
     platform.nukleros.io/project: external-secrets
 spec:
   replicas: 2
@@ -97,7 +97,7 @@ spec:
       labels:
         app.kubernetes.io/name: external-secrets
         app.kubernetes.io/instance: external-secrets
-        platform.nukleros.io/group: secrets
+        platform.nukleros.io/category: secrets
         platform.nukleros.io/project: external-secrets
     spec:
       serviceAccountName: external-secrets
@@ -150,7 +150,7 @@ metadata:
     app.kubernetes.io/name: external-secrets-webhook
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/version: v0.5.9
-    platform.nukleros.io/group: secrets
+    platform.nukleros.io/category: secrets
     platform.nukleros.io/project: external-secrets
 spec:
   replicas: 2
@@ -163,7 +163,7 @@ spec:
       labels:
         app.kubernetes.io/name: external-secrets-webhook
         app.kubernetes.io/instance: external-secrets
-        platform.nukleros.io/group: secrets
+        platform.nukleros.io/category: secrets
         platform.nukleros.io/project: external-secrets
     spec:
       hostNetwork: false

--- a/secrets/external-secrets/rbac.yaml
+++ b/secrets/external-secrets/rbac.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: external-secrets-cert-controller
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/version: v0.5.9
-    platform.nukleros.io/group: secrets
+    platform.nukleros.io/category: secrets
     platform.nukleros.io/project: external-secrets
 ---
 apiVersion: v1
@@ -20,7 +20,7 @@ metadata:
     app.kubernetes.io/name: external-secrets
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/version: v0.5.9
-    platform.nukleros.io/group: secrets
+    platform.nukleros.io/category: secrets
     platform.nukleros.io/project: external-secrets
 ---
 apiVersion: v1
@@ -32,7 +32,7 @@ metadata:
     app.kubernetes.io/name: external-secrets-webhook
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/version: v0.5.9
-    platform.nukleros.io/group: secrets
+    platform.nukleros.io/category: secrets
     platform.nukleros.io/project: external-secrets
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -43,7 +43,7 @@ metadata:
     app.kubernetes.io/name: external-secrets-cert-controller
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/version: v0.5.9
-    platform.nukleros.io/group: secrets
+    platform.nukleros.io/category: secrets
     platform.nukleros.io/project: external-secrets
 rules:
   - apiGroups:
@@ -100,7 +100,7 @@ metadata:
     app.kubernetes.io/name: external-secrets
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/version: v0.5.9
-    platform.nukleros.io/group: secrets
+    platform.nukleros.io/category: secrets
     platform.nukleros.io/project: external-secrets
 rules:
   - apiGroups:
@@ -193,7 +193,7 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
-    platform.nukleros.io/group: secrets
+    platform.nukleros.io/category: secrets
     platform.nukleros.io/project: external-secrets
 rules:
   - apiGroups:
@@ -217,7 +217,7 @@ metadata:
     app.kubernetes.io/version: v0.5.9
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
-    platform.nukleros.io/group: secrets
+    platform.nukleros.io/category: secrets
     platform.nukleros.io/project: external-secrets
 rules:
   - apiGroups:
@@ -241,7 +241,7 @@ metadata:
     app.kubernetes.io/name: external-secrets-cert-controller
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/version: v0.5.9
-    platform.nukleros.io/group: secrets
+    platform.nukleros.io/category: secrets
     platform.nukleros.io/project: external-secrets
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -260,7 +260,7 @@ metadata:
     app.kubernetes.io/name: external-secrets
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/version: v0.5.9
-    platform.nukleros.io/group: secrets
+    platform.nukleros.io/category: secrets
     platform.nukleros.io/project: external-secrets
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -280,7 +280,7 @@ metadata:
     app.kubernetes.io/name: external-secrets
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/version: v0.5.9
-    platform.nukleros.io/group: secrets
+    platform.nukleros.io/category: secrets
     platform.nukleros.io/project: external-secrets
 rules:
   - apiGroups:
@@ -318,7 +318,7 @@ metadata:
     app.kubernetes.io/name: external-secrets
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/version: v0.5.9
-    platform.nukleros.io/group: secrets
+    platform.nukleros.io/category: secrets
     platform.nukleros.io/project: external-secrets
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/secrets/external-secrets/service.yaml
+++ b/secrets/external-secrets/service.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/version: v0.5.9
     external-secrets.io/component: webhook
-    platform.nukleros.io/group: secrets
+    platform.nukleros.io/category: secrets
     platform.nukleros.io/project: external-secrets
 spec:
   type: ClusterIP

--- a/secrets/external-secrets/webhook.yaml
+++ b/secrets/external-secrets/webhook.yaml
@@ -4,7 +4,7 @@ metadata:
   name: secretstore-validate
   labels:
     external-secrets.io/component: webhook
-    platform.nukleros.io/group: secrets
+    platform.nukleros.io/category: secrets
     platform.nukleros.io/project: external-secrets
 webhooks:
   - name: validate.secretstore.external-secrets.io
@@ -60,7 +60,7 @@ metadata:
   name: externalsecret-validate
   labels:
     external-secrets.io/component: webhook
-    platform.nukleros.io/group: secrets
+    platform.nukleros.io/category: secrets
     platform.nukleros.io/project: external-secrets
 webhooks:
   - name: validate.externalsecret.external-secrets.io

--- a/secrets/reloader/deployment.yaml
+++ b/secrets/reloader/deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: secret-reloader
-    platform.nukleros.io/group: secrets
+    platform.nukleros.io/category: secrets
     platform.nukleros.io/project: reloader
   name: secret-reloader
   namespace: nukleros-secrets-system
@@ -13,13 +13,13 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: secret-reloader
-      platform.nukleros.io/group: secrets
+      platform.nukleros.io/category: secrets
       platform.nukleros.io/project: reloader
   template:
     metadata:
       labels:
         app.kubernetes.io/name: secret-reloader
-        platform.nukleros.io/group: secrets
+        platform.nukleros.io/category: secrets
         platform.nukleros.io/project: reloader
     spec:
       containers:

--- a/secrets/reloader/rbac.yaml
+++ b/secrets/reloader/rbac.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    platform.nukleros.io/group: secrets
+    platform.nukleros.io/category: secrets
     platform.nukleros.io/project: reloader
   name: secret-reloader
   namespace: nukleros-secrets-system
@@ -12,7 +12,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    platform.nukleros.io/group: secrets
+    platform.nukleros.io/category: secrets
     platform.nukleros.io/project: reloader
   name: secret-reloader
   namespace: nukleros-secrets-system
@@ -52,7 +52,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    platform.nukleros.io/group: secrets
+    platform.nukleros.io/category: secrets
     platform.nukleros.io/project: reloader
   name: secret-reloader
   namespace: nukleros-secrets-system


### PR DESCRIPTION
The platform.nukleros.io/group tag is being renamed to platform.nukleros.io/category to avoid confusion with API groups since these tags will end up on resources that could be managed by custom APIs.

Signed-off-by: Rich Lander <lander2k2@protonmail.com>